### PR TITLE
Make Forcings Engine Installable via pip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ __pycache__/
 *.py[cod]
 .env
 .python-version
+build/
 
 # pyenv #
 #########

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/__init__.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/__init__.py
@@ -1,1 +1,1 @@
-from .bmi_model import bmi_model
+__version__ = '0.0.1'

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/__init__.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/__init__.py
@@ -1,1 +1,3 @@
 __version__ = '0.0.1'
+
+from .bmi_model import NWMv3_Forcing_Engine_BMI_model as BMIForcingsEngine

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_model.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_model.py
@@ -13,22 +13,22 @@ import yaml
 from bmipy import Bmi
 
 # Import BMI grid functions to advertise grid features
-from bmi_grid import Grid, GridType
+from .bmi_grid import Grid, GridType
 
 # Here is the model we want to run
-from model import NWMv3_Forcing_Engine_model
+from .model import NWMv3_Forcing_Engine_model
 
 ###### NWMv3.0 Forcings Engine modules ######
 import ESMF
 
-from core import config
-from core import err_handler
-from core import forcingInputMod
-from core import forecastMod
-from core import geoMod
-from core import ioMod
-from core import parallel
-from core import suppPrecipMod
+from .core import config
+from .core import err_handler
+from .core import forcingInputMod
+from .core import forecastMod
+from .core import geoMod
+from .core import ioMod
+from .core import parallel
+from .core import suppPrecipMod
 
 class UnknownBMIVariable(RuntimeError):
     pass

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_model.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_model.py
@@ -19,7 +19,11 @@ from .bmi_grid import Grid, GridType
 from .model import NWMv3_Forcing_Engine_model
 
 ###### NWMv3.0 Forcings Engine modules ######
-import ESMF
+try:
+    import esmpy as ESMF
+except ImportError:
+    import ESMF
+
 
 from .core import config
 from .core import err_handler

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/bias_correction.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/bias_correction.py
@@ -12,7 +12,7 @@ import time
 import numpy as np
 from netCDF4 import Dataset
 
-from core import err_handler
+from . import err_handler
 
 PARAM_NX = 384
 PARAM_NY = 190

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/config.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/config.py
@@ -5,8 +5,8 @@ import os
 
 import numpy as np
 
-from core import time_handling
-from core import err_handler
+from . import time_handling
+from . import err_handler
 
 
 class ConfigOptions:

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/config.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/config.py
@@ -827,7 +827,7 @@ class ConfigOptions:
 
         # Read in the temperature downscaling options.
         # Create temporary array to hold flags of if we need input parameter files.
-        param_flag = np.empty([len(self.input_forcings)], np.int)
+        param_flag = np.empty([len(self.input_forcings)], int)
         param_flag[:] = 0
         try:
             self.t2dDownscaleOpt = cfg['TemperatureDownscaling']

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/disaggregateMod.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/disaggregateMod.py
@@ -8,7 +8,7 @@ import os.path
 import numpy as np
 from netCDF4 import Dataset
 
-from core import err_handler
+from . import err_handler
 
 test_enabled = True
 

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/disaggregateMod.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/disaggregateMod.py
@@ -148,9 +148,9 @@ def ak_ext_ana_disaggregate(input_forcings, supplemental_precip, config_options,
 
     ana_sum = np.array([],dtype=np.float32)
     target_data = np.array([],dtype=np.float32)
-    ana_all_zeros = np.array([],dtype=np.bool)
-    ana_no_zeros = np.array([],dtype=np.bool)
-    target_data_no_zeros = np.array([],dtype=np.bool)
+    ana_all_zeros = np.array([],dtype=bool)
+    ana_no_zeros = np.array([],dtype=bool)
+    target_data_no_zeros = np.array([],dtype=bool)
     if mpi_config.rank == 0:
         config_options.statusMsg = f"Performing hourly disaggregation of {supplemental_precip.file_in2}"
         err_handler.log_msg(config_options, mpi_config)

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/downscale.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/downscale.py
@@ -10,7 +10,7 @@ import time
 import numpy as np
 from netCDF4 import Dataset
 
-from core import err_handler
+from . import err_handler
 
 
 def run_downscaling(input_forcings, config_options, geo_meta_wrf_hydro, mpi_config):

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/downscale.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/downscale.py
@@ -1074,18 +1074,18 @@ def TOPO_RAD_ADJ_DRVR(GeoMetaWrfHydro,ConfigOptions,input_forcings,COSZEN,declin
     COSZEN[np.where(COSZEN < 1E-4)] = 1E-4
 
     if(ConfigOptions.grid_type == "gridded"):
-        corr_frac = np.empty([ny, nx], np.int)
-        # shadow_mask = np.empty([ny,nx],np.int)
-        diffuse_frac = np.empty([ny, nx], np.int)
+        corr_frac = np.empty([ny, nx], int)
+        # shadow_mask = np.empty([ny,nx],int)
+        diffuse_frac = np.empty([ny, nx], int)
         corr_frac[:, :] = 0
         diffuse_frac[:, :] = 0
         # shadow_mask[:,:] = 0
         indTmp = np.where((GeoMetaWrfHydro.slope[:,:] == 0.0) &
                           (SWDOWN <= 10.0))
     else:
-        corr_frac = np.empty([ny], np.int)
-        # shadow_mask = np.empty([ny],np.int)
-        diffuse_frac = np.empty([ny], np.int)
+        corr_frac = np.empty([ny], int)
+        # shadow_mask = np.empty([ny],int)
+        diffuse_frac = np.empty([ny], int)
         corr_frac[:] = 0
         diffuse_frac[:] = 0
         # shadow_mask[:] = 0
@@ -1172,10 +1172,10 @@ def TOPO_RAD_ADJ_DRVR_unstructured(GeoMetaWrfHydro,input_forcings,COSZEN,COSZEN_
     COSZEN[np.where(COSZEN < 1E-4)] = 1E-4
     COSZEN_elem[np.where(COSZEN_elem < 1E-4)] = 1E-4
 
-    corr_frac = np.empty([ny], np.int)
-    corr_frac_elem = np.empty([ny_elem], np.int)
-    diffuse_frac = np.empty([ny], np.int)
-    diffuse_frac_elem = np.empty([ny_elem], np.int)
+    corr_frac = np.empty([ny], int)
+    corr_frac_elem = np.empty([ny_elem], int)
+    diffuse_frac = np.empty([ny], int)
+    diffuse_frac_elem = np.empty([ny_elem], int)
     corr_frac[:] = 0
     corr_frac_elem[:] = 0
     diffuse_frac[:] = 0

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/forcingInputMod.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/forcingInputMod.py
@@ -6,9 +6,9 @@ initializing ESMF grids and regrid objects), etc
 """
 import numpy as np
 
-from core import time_handling
-from core import regrid
-from core import timeInterpMod
+from . import time_handling
+from . import regrid
+from . import timeInterpMod
 
 
 class input_forcings:

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/forecastMod.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/forecastMod.py
@@ -1,11 +1,11 @@
 import datetime
 import os
 
-from core import bias_correction
-from core import downscale
-from core import err_handler
-from core import layeringMod
-from core import disaggregateMod
+from . import bias_correction
+from . import downscale
+from . import err_handler
+from . import layeringMod
+from . import disaggregateMod
 
 
 def process_forecasts(ConfigOptions, wrfHydroGeoMeta, inputForcingMod, suppPcpMod, MpiConfig, OutputObj):

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/geoMod.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/geoMod.py
@@ -1,6 +1,10 @@
 import math
 
-import ESMF
+try:
+    import esmpy as ESMF
+except ImportError:
+    import ESMF
+
 import numpy as np
 from netCDF4 import Dataset
 from scipy import spatial

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/ioMod.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/ioMod.py
@@ -14,7 +14,7 @@ import subprocess
 import numpy as np
 from netCDF4 import Dataset
 
-from core import err_handler
+from . import err_handler
 
 
 class OutputObj:

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/layeringMod.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/layeringMod.py
@@ -3,7 +3,7 @@ Layering module for implementing various layering schemes in the WRF-Hydro forci
 Future functionality may include blenidng, etc.
 """
 import numpy as np
-from core import err_handler
+from . import err_handler
 
 def layer_final_forcings(OutputObj,input_forcings,ConfigOptions,MpiConfig):
     """

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/parallel.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/parallel.py
@@ -3,7 +3,7 @@ import mpi4py
 mpi4py.rc.threaded = False
 from mpi4py import MPI
 
-from core import err_handler
+from . import err_handler
 
 
 class MpiConfig:

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/parallel.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/parallel.py
@@ -140,7 +140,7 @@ class MpiConfig:
                 data_type_flag = 1
             if src_array.dtype == np.float64:
                 data_type_flag = 2
-            if src_array.dtype == np.bool:
+            if src_array.dtype == bool:
                 data_type_flag = 3
 
         # Broadcast the data_type_flag to other processors
@@ -206,7 +206,7 @@ class MpiConfig:
             recvbuf=np.empty([counts[self.rank]],np.float32)
         elif data_type_flag == 3: 
             data_type = MPI.BOOL
-            recvbuf = np.empty([counts[self.rank]], np.bool)
+            recvbuf = np.empty([counts[self.rank]], bool)
         else:
             data_type = MPI.DOUBLE
             recvbuf = np.empty([counts[self.rank]], np.float64)

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
@@ -7,7 +7,11 @@ import sys
 import traceback
 import time
 
-import ESMF
+try:
+    import esmpy as ESMF
+except ImportError:
+    import ESMF
+
 import numpy as np
 
 from . import err_handler

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
@@ -10,9 +10,9 @@ import time
 import ESMF
 import numpy as np
 
-from core import err_handler
-from core import ioMod
-from core import timeInterpMod
+from . import err_handler
+from . import ioMod
+from . import timeInterpMod
 
 NETCDF = "NETCDF"
 GRIB2 = "GRIB2"

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/suppPrecipMod.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/suppPrecipMod.py
@@ -4,9 +4,9 @@ that will replace precipitation in the final output files.
 """
 import numpy as np
 
-from core import time_handling
-from core import regrid
-from core import timeInterpMod
+from . import time_handling
+from . import regrid
+from . import timeInterpMod
 
 
 class supplemental_precip:

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/timeInterpMod.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/timeInterpMod.py
@@ -3,7 +3,7 @@ Temporal interpolation input forcings to the current output timestep.
 """
 import numpy as np
 
-from core import err_handler
+from . import err_handler
 
 
 def no_interpolation(input_forcings,ConfigOptions,MpiConfig):

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/time_handling.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/time_handling.py
@@ -7,8 +7,8 @@ import os
 
 import numpy as np
 
-from core import err_handler
-from core.forcingInputMod import input_forcings
+from . import err_handler
+from .forcingInputMod import input_forcings
 NETCDF = input_forcings.NETCDF
 
 

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/model.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/model.py
@@ -3,11 +3,11 @@ import os
 import pandas as pd
 import numpy as np
 
-from core import bias_correction
-from core import downscale
-from core import err_handler
-from core import layeringMod
-from core import disaggregateMod
+from .core import bias_correction
+from .core import downscale
+from .core import err_handler
+from .core import layeringMod
+from .core import disaggregateMod
 
 class NWMv3_Forcing_Engine_model():
     # TODO: refactor the bmi_model.py file and this to have this type maintain its own state.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,31 @@
+[project]
+name = "ngen-forcings"
+authors = [
+    { name = "Jason Ducker", email = "jason.ducker@noaa.gov" }
+]
+description = "NextGen Forcings Engine"
+readme = "README.md"
+requires-python = ">= 3.8"
+dependencies = [
+    "bmipy",
+    "bokeh",
+    "pandas>=1.15",
+    "netCDF4",
+    "mpi4py>=3.1.4",
+    "esmpy>=8.1.0",
+    "numpy>=1.20.1"
+]
+dynamic = ["version"]
+
+[project.urls]
+Repository = "https://github.com/NOAA-OWP/ngen-forcing"
+Issues = "https://github.com/NOAA-OWP/ngen-forcing/issues"
+
+[build-system]
+requires = ["setuptools >= 61.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["NextGen_Forcings_Engine_BMI"]
+include = ["NextGen_Forcings_Engine*"]
+namespaces = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,8 @@ authors = [
     { name = "Jason Ducker", email = "jason.ducker@noaa.gov" }
 ]
 description = "NextGen Forcings Engine"
-readme = "README.md"
+readme = { file = "README.md", content-type = "text/markdown" }
+license = { file = "LICENSE" }
 requires-python = ">= 3.8"
 dependencies = [
     "bmipy",
@@ -29,3 +30,6 @@ build-backend = "setuptools.build_meta"
 where = ["NextGen_Forcings_Engine_BMI"]
 include = ["NextGen_Forcings_Engine*"]
 namespaces = false
+
+[tool.setuptools.dynamic]
+version = { attr = "NextGen_Forcings_Engine.__version__" }


### PR DESCRIPTION
Hi Jason! This PR adds a pyproject.toml so that the forcings engine is installable via `pip`.

In summary:
- Adds `pyproject.toml` to root directory.
- Adds `__init__.py` to `core/` to initialize it as a submodule.
- Adds `__version__` entry into package init.
- Adds `build/` directory to `.gitignore`.
- Adds top-level BMI class alias, `BMIForcingsEngine`.
- Uses relative imports for intra-package imports.
- Replaces deprecated numpy aliases with base types (`np.int` and `np.bool`).
- Adds try/except around ESMF imports to handle the name change from `ESMF` to `esmpy`

I also think we can move this into the NOAA-OWP org, considering that integration into NGen is progressing.

