### PR TITLE
Add MPI communicator passing prior to model initialization

### DIFF
--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_model.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_model.py
@@ -24,7 +24,6 @@ try:
 except ImportError:
     import ESMF
 
-
 from .core import config
 from .core import err_handler
 from .core import forcingInputMod
@@ -33,6 +32,8 @@ from .core import geoMod
 from .core import ioMod
 from .core import parallel
 from .core import suppPrecipMod
+
+from mpi4py import MPI
 
 class UnknownBMIVariable(RuntimeError):
     pass
@@ -46,6 +47,7 @@ class NWMv3_Forcing_Engine_BMI_model(Bmi):
         self._start_time = 0.0
         self._end_time = np.finfo(float).max
         self._model = None
+        self._comm = None
         self.var_array_lengths = 1
 
     #----------------------------------------------
@@ -122,7 +124,7 @@ class NWMv3_Forcing_Engine_BMI_model(Bmi):
         # Initialize our MPI communication
         self._mpi_meta = parallel.MpiConfig()
         try:
-            self._mpi_meta.initialize_comm(self._job_meta)
+            self._mpi_meta.initialize_comm(self._job_meta, comm=self._comm)
         except:
             err_handler.err_out_screen(self._job_meta.errMsg)
         print("Finished initializing MPI communicator")
@@ -658,7 +660,11 @@ class NWMv3_Forcing_Engine_BMI_model(Bmi):
         values : np.ndarray
               Array of new values.
         """ 
-        self._values[var_name][:] = values
+
+        if var_name == 'bmi_mpi_comm':
+            self._comm = MPI.Comm.f2py(values[0])
+        else:
+            self._values[var_name][:] = values
 
     #------------------------------------------------------------ 
     def set_value_at_indices(self, var_name: str, indices: np.ndarray, src: np.ndarray):

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_model.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_model.py
@@ -124,7 +124,8 @@ class NWMv3_Forcing_Engine_BMI_model(Bmi):
         # Initialize our MPI communication
         self._mpi_meta = parallel.MpiConfig()
         try:
-            self._mpi_meta.initialize_comm(self._job_meta, comm=self._comm)
+            comm = MPI.Comm.f2py(self._comm) if self._comm is not None else None
+            self._mpi_meta.initialize_comm(self._job_meta, comm=comm)
         except:
             err_handler.err_out_screen(self._job_meta.errMsg)
         print("Finished initializing MPI communicator")
@@ -662,7 +663,7 @@ class NWMv3_Forcing_Engine_BMI_model(Bmi):
         """ 
 
         if var_name == 'bmi_mpi_comm':
-            self._comm = MPI.Comm.f2py(values[0])
+            self._comm = values[0]
         else:
             self._values[var_name][:] = values
 

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/parallel.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/parallel.py
@@ -21,13 +21,13 @@ class MpiConfig:
         self.rank = None
         self.size = None 
 
-    def initialize_comm(self, config_options):
+    def initialize_comm(self, config_options, comm = None):
         """
         Initial function to initialize MPI.
         :return:
         """
         try:
-            self.comm = MPI.COMM_WORLD
+            self.comm = MPI.COMM_WORLD if comm is None else comm
             self.comm.Set_errhandler(MPI.ERRORS_ARE_FATAL)
         except AttributeError as ae:
             config_options.errMsg = "Unable to initialize the MPI Communicator object"

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/parallel.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/parallel.py
@@ -27,7 +27,7 @@ class MpiConfig:
         :return:
         """
         try:
-            self.comm = MPI.COMM_WORLD if comm is None else comm
+            self.comm = comm if comm is not None else MPI.COMM_WORLD
             self.comm.Set_errhandler(MPI.ERRORS_ARE_FATAL)
         except AttributeError as ae:
             config_options.errMsg = "Unable to initialize the MPI Communicator object"


### PR DESCRIPTION
This PR adds a new instance variable to the Forcing Engine BMI: `_comm`, which holds a communicator handle, and is passed to `MpiConfig` as a communicator at initialization.

## Additions

- Adds `_comm: int` to the BMI model class.
- Adds a `comm` parameter to `MpiConfig.initialize_comm()` defaulting to None, which sets the communicator if it is not None.
- Adds a conditional check to `set_value` to assign the communicator handle to `self._comm` if the passed variable name is `bmi_mpi_comm`.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows project standards (link if applicable)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

